### PR TITLE
fix: include stackKeyId in issue/issues

### DIFF
--- a/src/issue.ts
+++ b/src/issue.ts
@@ -45,11 +45,11 @@ export function formatIssueOutput(
   if (crash.ipAddress) {
     text += `IP Address: ${crash.ipAddress}\n`;
   }
-  if (crash.stackKey) {
-    text += `Stack Key: ${crash.stackKey}\n`;
-  }
   if (crash.stackKeyId) {
     text += `Stack Key ID: ${crash.stackKeyId}\n`;
+  }
+  if (crash.stackKey) {
+    text += `Stack Key: ${crash.stackKey}\n`;
   }
 
   text += `Linked Defects: ${crash.stackKeyDefectLabel || "None"}\n`;

--- a/src/issues.ts
+++ b/src/issues.ts
@@ -81,8 +81,11 @@ export function formatIssuesOutput(
       if (row.email) {
         text += `Email: ${row.email}\n`;
       }
+      if (row.stackKeyId) {
+        text += `Stack Key ID: ${row.stackKeyId}\n`;
+      }
       if (row.stackKey) {
-        text += `\n${row.stackKey}`;
+        text += `Stack Key: ${row.stackKey}\n`;
       }
 
       text += `Linked Defects: ${row.skDefectLabel || "None"}\n`;


### PR DESCRIPTION
### Description

Allows create-defect to use stackKeyId instead of trying to use crashId.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
