### PR TITLE
fix: list-issues time filtering

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,26 +1,32 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug Tests",
+      "name": "Attach to MCP Server",
       "type": "node",
-      "request": "launch",
+      "request": "attach",
+      "port": 9229,
       "skipFiles": ["<node_internals>/**"],
-      "program": "${workspaceFolder}/node_modules/jasmine/bin/jasmine.js",
-      "args": ["--config=build/spec/support/jasmine.json"],
-      "preLaunchTask": "npm: build:test",
       "outFiles": ["${workspaceFolder}/build/**/*.js"],
       "sourceMaps": true,
       "resolveSourceMapLocations": [
         "${workspaceFolder}/**",
         "!**/node_modules/**"
-      ],
-      "env": {
-        "NODE_OPTIONS": "--enable-source-maps --experimental-vm-modules"
-      }
+      ]
+    },
+    {
+      "name": "Debug Tests",
+      "type": "node",
+      "request": "launch",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
+      "args": ["run"],
+      "outFiles": ["${workspaceFolder}/build/**/*.js"],
+      "sourceMaps": true,
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ]
     }
   ]
 }

--- a/scripts/debug.mjs
+++ b/scripts/debug.mjs
@@ -22,6 +22,7 @@ const args = [
   "@modelcontextprotocol/inspector",
   ...envVars.reduce((acc, env) => [...acc, "-e", env], []),
   "node",
+  "--inspect-brk",
   "build/index.js",
 ];
 

--- a/src/issues.ts
+++ b/src/issues.ts
@@ -41,7 +41,7 @@ export async function listIssues(
   if (options.startDate || options.endDate) {
     filterGroups.push(
       QueryFilterGroup.fromTimeFrame(
-        "date",
+        "crashTime",
         options.startDate ? new Date(options.startDate) : undefined,
         options.endDate ? new Date(options.endDate) : undefined
       )

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -1,5 +1,4 @@
 import {
-  QueryFilter,
   QueryFilterGroup,
   SummaryApiClient,
   SummaryApiRow,
@@ -20,19 +19,12 @@ export async function getSummary(
   const summaryClient = new SummaryApiClient(bugsplat);
   let filterGroups: QueryFilterGroup[] = [];
 
-  if (options.startDate) {
+  if (options.startDate || options.endDate) {
     filterGroups.push(
-      new QueryFilterGroup([
-        new QueryFilter(options.startDate, "GREATER_THAN", "firstReport"),
-      ])
-    );
-  }
-
-  if (options.endDate) {
-    filterGroups.push(
-      QueryFilterGroup.fromColumnValues(
-        [new Date(options.endDate).toISOString()],
-        "firstReport"
+      QueryFilterGroup.fromTimeFrame(
+        "firstReport",
+        options.startDate ? new Date(options.startDate) : undefined,
+        options.endDate ? new Date(options.endDate) : undefined
       )
     );
   }


### PR DESCRIPTION
### Description

We were filtering a non-existent "date" column instead of "crashTime". Also simplified the way summary filtering is done and added some debug helpers.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
